### PR TITLE
Feature/constraint evaluator empty fix containers

### DIFF
--- a/src/main/java/de/nexus/mmlcli/constraint/entity/FixContainerEntity.java
+++ b/src/main/java/de/nexus/mmlcli/constraint/entity/FixContainerEntity.java
@@ -6,6 +6,8 @@ import java.util.stream.Collectors;
 public class FixContainerEntity {
     private boolean isEnableContainer;
     private String fixTitle;
+
+    private boolean isEmptyMatchFix;
     private List<IFixStatementEntity> statements;
 
     public boolean isEnableContainer() {
@@ -16,11 +18,15 @@ public class FixContainerEntity {
         return statements;
     }
 
+    public boolean isEmptyMatchFix() {
+        return isEmptyMatchFix;
+    }
+
     public String toJavaCode() {
         if (this.isEnableContainer) {
-            return String.format("new EnablingFixContainer(\"%s\", List.of(%s))", fixTitle, this.statements.stream().map(IFixStatementEntity::toJavaCode).collect(Collectors.joining(", ")));
+            return String.format("new EnablingFixContainer(\"%s\", List.of(%s), %b)", fixTitle, this.statements.stream().map(IFixStatementEntity::toJavaCode).collect(Collectors.joining(", ")), this.isEmptyMatchFix);
         } else {
-            return String.format("new DisablingFixContainer(\"%s\", List.of(%s))", fixTitle, this.statements.stream().map(IFixStatementEntity::toJavaCode).collect(Collectors.joining(", ")));
+            return String.format("new DisablingFixContainer(\"%s\", List.of(%s), %b)", fixTitle, this.statements.stream().map(IFixStatementEntity::toJavaCode).collect(Collectors.joining(", ")), this.isEmptyMatchFix);
         }
     }
 }

--- a/src/main/java/de/nexus/modelserver/DisablingFixContainer.java
+++ b/src/main/java/de/nexus/modelserver/DisablingFixContainer.java
@@ -3,7 +3,7 @@ package de.nexus.modelserver;
 import java.util.List;
 
 public class DisablingFixContainer extends FixContainer {
-    public DisablingFixContainer(String fixTitle, List<FixStatement> statements) {
-        super(fixTitle, statements);
+    public DisablingFixContainer(String fixTitle, List<FixStatement> statements, boolean emptyMatchFix) {
+        super(fixTitle, statements, emptyMatchFix);
     }
 }

--- a/src/main/java/de/nexus/modelserver/EnablingFixContainer.java
+++ b/src/main/java/de/nexus/modelserver/EnablingFixContainer.java
@@ -3,7 +3,7 @@ package de.nexus.modelserver;
 import java.util.List;
 
 public class EnablingFixContainer extends FixContainer {
-    public EnablingFixContainer(String fixTitle, List<FixStatement> statements) {
-        super(fixTitle, statements);
+    public EnablingFixContainer(String fixTitle, List<FixStatement> statements, boolean emptyMatchFix) {
+        super(fixTitle, statements, emptyMatchFix);
     }
 }

--- a/src/main/java/de/nexus/modelserver/FixContainer.java
+++ b/src/main/java/de/nexus/modelserver/FixContainer.java
@@ -4,11 +4,13 @@ import java.util.List;
 
 public abstract class FixContainer {
     protected final List<FixStatement> statements;
+    protected final boolean emptyMatchFix;
     protected final String fixTitle;
 
-    public FixContainer(String fixTitle, List<FixStatement> statements) {
+    public FixContainer(String fixTitle, List<FixStatement> statements, boolean emtpyMatchFix) {
         this.fixTitle = fixTitle;
         this.statements = statements;
+        this.emptyMatchFix = emtpyMatchFix;
     }
 
     public List<FixStatement> getStatements() {
@@ -17,5 +19,9 @@ public abstract class FixContainer {
 
     public String getFixTitle() {
         return fixTitle;
+    }
+
+    public boolean isEmptyMatchFix() {
+        return emptyMatchFix;
     }
 }

--- a/src/main/java/de/nexus/modelserver/ProtoMapper.java
+++ b/src/main/java/de/nexus/modelserver/ProtoMapper.java
@@ -66,12 +66,15 @@ public class ProtoMapper {
     }
 
     public static ModelServerConstraints.FixMatch map(IMatch match, List<FixContainer> variants, IndexedEMFLoader emfLoader) {
-        List<ModelServerConstraints.FixVariant> protoVariants = variants.stream().map(x -> ProtoMapper.map(match, x, emfLoader)).toList();
+        boolean isEmptyMatch = match instanceof EmptyMatch;
+
+        List<ModelServerConstraints.FixVariant> protoVariants = variants.stream().filter(x -> x.isEmptyMatchFix() == isEmptyMatch).map(x -> ProtoMapper.map(match, x, emfLoader)).toList();
         List<ModelServerConstraints.MatchNode> matchNodes = match.getParameters().stream().map(x -> ProtoMapper.map(x, emfLoader)).toList();
 
         return ModelServerConstraints.FixMatch.newBuilder()
                 .addAllVariants(protoVariants)
                 .addAllNodes(matchNodes)
+                .setEmptyMatch(isEmptyMatch)
                 .build();
     }
 

--- a/src/main/java/de/nexus/modelserver/evaltree/EvalTreeFixProposer.java
+++ b/src/main/java/de/nexus/modelserver/evaltree/EvalTreeFixProposer.java
@@ -5,10 +5,10 @@ import de.nexus.expr.PatternPrimaryExpressionEntity;
 import de.nexus.expr.UnaryOperator;
 import de.nexus.modelserver.*;
 import de.nexus.modelserver.proto.ModelServerConstraints;
+import de.nexus.modelserver.runtime.EmptyMatch;
+import de.nexus.modelserver.runtime.IMatch;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 public class EvalTreeFixProposer {
     private final AbstractConstraint constraint;
@@ -175,6 +175,12 @@ public class EvalTreeFixProposer {
 
         Pattern pattern = constraint.getPattern(patternVariable);
 
-        return pattern.getMatches().stream().map(x -> ProtoMapper.map(x, fixContainers, emfLoader)).toList();
+        Set<IMatch> matches = new HashSet<>(pattern.getMatches());
+
+        if (fixContainers.stream().anyMatch(FixContainer::isEmptyMatchFix)) {
+            matches.add(EmptyMatch.INSTANCE);
+        }
+
+        return matches.stream().map(x -> ProtoMapper.map(x, fixContainers, emfLoader)).toList();
     }
 }

--- a/src/main/java/de/nexus/modelserver/runtime/EmptyMatch.java
+++ b/src/main/java/de/nexus/modelserver/runtime/EmptyMatch.java
@@ -1,0 +1,48 @@
+package de.nexus.modelserver.runtime;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+public class EmptyMatch implements IMatch {
+
+    public static EmptyMatch INSTANCE;
+
+    static {
+        EmptyMatch.INSTANCE = new EmptyMatch();
+    }
+
+    private EmptyMatch() {
+    }
+
+    @Override
+    public String getPatternName() {
+        return "EMPTY_MATCH";
+    }
+
+    @Override
+    public Object get(String name) {
+        return null;
+    }
+
+    @Override
+    public Collection<String> getParameterNames() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<Object> getObjects() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Set<Map.Entry<String, Object>> getParameters() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public long getHashCode() {
+        return 0;
+    }
+}

--- a/src/main/proto/de/nexus/modelserver/ModelServerConstraints.proto
+++ b/src/main/proto/de/nexus/modelserver/ModelServerConstraints.proto
@@ -54,6 +54,7 @@ message FixProposal {
 message FixMatch {
   repeated FixVariant variants = 1;
   repeated MatchNode nodes = 2;
+  bool emptyMatch = 3;
 }
 
 message MatchNode {


### PR DESCRIPTION
FixVariants are fundamentally linked to matches, which means that we calculate all possible (predefined) variants for all matches. However, there are no matches for Enable Fixes, as these are to be generated by the fix. So far, this has meant that no enable fixes have been made available to users.

In https://github.com/eMoflon/model-modeling-language/pull/7 we have therefore extended GCL with empty matches and empty fix proposals to address this problem.

In this pull request, we extend the ModelServer by introducing a new empty match class. Furthermore, we store for all FixContainers whether they are intended for an empty match.

The EvalTreeProposer then takes this into account when calculating FixProposals and returns a result for the empty match if a corresponding fix is available.