### PR TITLE
Feature/constraint evaluator advanced fix set statement

### DIFF
--- a/src/main/java/de/nexus/expr/EnumValuePrimaryExpressionEntity.java
+++ b/src/main/java/de/nexus/expr/EnumValuePrimaryExpressionEntity.java
@@ -29,7 +29,7 @@ public class EnumValuePrimaryExpressionEntity implements PrimaryExpressionEntity
 
     @Override
     public String toInterpretableJavaCode() {
-        throw new UnsupportedOperationException("EnumValuePrimaryExpressions cannot be translated to interpretable Java code!");
+        return String.format("ValueWrapper.create(\"%s\")", this.value);
     }
 
     @Override

--- a/src/main/java/de/nexus/mmlcli/constraint/entity/ConstraintDocumentEntity.java
+++ b/src/main/java/de/nexus/mmlcli/constraint/entity/ConstraintDocumentEntity.java
@@ -25,6 +25,7 @@ public class ConstraintDocumentEntity {
         builder.registerTypeAdapter(ConstraintAssertionEntity.class, new ConstraintAssertionEntityDeserializer());
         builder.registerTypeAdapter(TemplateStringElementEntity.class, new TemplateStringElementEntityDeserializer());
         builder.registerTypeAdapter(IFixStatementEntity.class, new FixStatementEntityDeserializer());
+        builder.registerTypeAdapter(FixSetAttributeEntity.class, new FixSetAttributeEntityDeserializer());
 
         Gson gson = builder.create();
         return gson.fromJson(serialized, ConstraintDocumentEntity.class);

--- a/src/main/java/de/nexus/mmlcli/constraint/entity/FixSetAttributeEntity.java
+++ b/src/main/java/de/nexus/mmlcli/constraint/entity/FixSetAttributeEntity.java
@@ -1,16 +1,14 @@
 package de.nexus.mmlcli.constraint.entity;
 
-import de.nexus.expr.EnumValuePrimaryExpressionEntity;
-import de.nexus.expr.PrimaryExpressionEntity;
-import de.nexus.expr.PrimitivePrimaryExpressionEntity;
+import de.nexus.expr.ExpressionEntity;
 
 public class FixSetAttributeEntity implements IFixStatementEntity {
     private final String patternNodeName;
     private final String attributeName;
     private final boolean customizationRequired;
-    private final PrimaryExpressionEntity attributeValue;
+    private final ExpressionEntity attributeValue;
 
-    public FixSetAttributeEntity(String patternNodeName, String attributeName, boolean customizationRequired, PrimaryExpressionEntity attributeValue) {
+    public FixSetAttributeEntity(String patternNodeName, String attributeName, boolean customizationRequired, ExpressionEntity attributeValue) {
         this.patternNodeName = patternNodeName;
         this.attributeName = attributeName;
         this.customizationRequired = customizationRequired;
@@ -29,20 +27,12 @@ public class FixSetAttributeEntity implements IFixStatementEntity {
         return customizationRequired;
     }
 
-    public PrimaryExpressionEntity getAttributeValue() {
+    public ExpressionEntity getAttributeValue() {
         return attributeValue;
     }
 
     @Override
     public String toJavaCode() {
-        String attributeValue = "";
-        if (!this.customizationRequired) {
-            if (this.attributeValue instanceof PrimitivePrimaryExpressionEntity<?> primitiveValue) {
-                attributeValue = primitiveValue.getAsString();
-            } else if (this.attributeValue instanceof EnumValuePrimaryExpressionEntity enumValue) {
-                attributeValue = enumValue.getValue();
-            }
-        }
-        return String.format("new FixSetStatement(\"%s\", \"%s\", %b, \"%s\")", this.patternNodeName, this.attributeName, this.customizationRequired, attributeValue);
+        return String.format("new FixSetStatement(\"%s\", \"%s\", %b, (match) -> %s.getAsString())", this.patternNodeName, this.attributeName, this.customizationRequired, attributeValue.toInterpretableJavaCode());
     }
 }

--- a/src/main/java/de/nexus/mmlcli/constraint/entity/FixSetAttributeEntityDeserializer.java
+++ b/src/main/java/de/nexus/mmlcli/constraint/entity/FixSetAttributeEntityDeserializer.java
@@ -1,0 +1,34 @@
+package de.nexus.mmlcli.constraint.entity;
+
+import com.google.gson.*;
+import de.nexus.expr.*;
+
+import java.lang.reflect.Type;
+
+public class FixSetAttributeEntityDeserializer implements JsonDeserializer<FixSetAttributeEntity> {
+
+    @Override
+    public FixSetAttributeEntity deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+        JsonObject jsonObject = jsonElement.getAsJsonObject();
+        String patternNodeName = jsonObject.get("patternNodeName").getAsString();
+        String attributeName = jsonObject.get("attributeName").getAsString();
+        boolean customizationRequired = jsonObject.get("customizationRequired").getAsBoolean();
+        JsonObject exprContainerObject = jsonObject.getAsJsonObject("attributeValue");
+
+        if (exprContainerObject != null && !customizationRequired) {
+            JsonObject exprObject = exprContainerObject.getAsJsonObject("expr");
+            boolean isBinary = exprContainerObject.get("isBinary").getAsBoolean();
+            boolean isUnary = exprContainerObject.get("isUnary").getAsBoolean();
+
+            Type exprType = isBinary ? BinaryExpressionEntity.class : isUnary ? UnaryExpressionEntity.class : PrimaryExpressionEntity.class;
+
+            ExpressionEntity expressionEntity = jsonDeserializationContext.deserialize(exprObject, exprType);
+
+
+            return new FixSetAttributeEntity(patternNodeName, attributeName, customizationRequired, expressionEntity);
+        } else if (exprContainerObject == null && !customizationRequired) {
+            throw new IllegalStateException("ExpressionConstrainer is null but customizationRequired is false");
+        }
+        return new FixSetAttributeEntity(patternNodeName, attributeName, customizationRequired, new PrimitivePrimaryExpressionEntity<>("", PrimaryExpressionEntityType.STRING));
+    }
+}

--- a/src/main/java/de/nexus/modelserver/FixSetStatement.java
+++ b/src/main/java/de/nexus/modelserver/FixSetStatement.java
@@ -4,13 +4,13 @@ public class FixSetStatement implements FixStatement {
     private final String patternNodeName;
     private final String attributeName;
     private final boolean customizationRequired;
-    private final String attributeValue;
+    private final MatchBasedStringInterpreter attributeValueInterpreter;
 
-    public FixSetStatement(String patternNodeName, String attributeName, boolean customizationRequired, String attributeValue) {
+    public FixSetStatement(String patternNodeName, String attributeName, boolean customizationRequired, MatchBasedStringInterpreter attributeValue) {
         this.patternNodeName = patternNodeName;
         this.attributeName = attributeName;
         this.customizationRequired = customizationRequired;
-        this.attributeValue = attributeValue;
+        this.attributeValueInterpreter = attributeValue;
     }
 
     public String getPatternNodeName() {
@@ -25,7 +25,7 @@ public class FixSetStatement implements FixStatement {
         return customizationRequired;
     }
 
-    public String getAttributeValue() {
-        return attributeValue;
+    public MatchBasedStringInterpreter getAttributeValueInterpreter() {
+        return attributeValueInterpreter;
     }
 }

--- a/src/main/java/de/nexus/modelserver/ProtoMapper.java
+++ b/src/main/java/de/nexus/modelserver/ProtoMapper.java
@@ -229,7 +229,7 @@ public class ProtoMapper {
         return ModelServerEditStatements.EditSetAttributeRequest.newBuilder()
                 .setNode(protoNode)
                 .setAttributeName(fixStatement.getAttributeName())
-                .setAttributeValue(fixStatement.getAttributeValue())
+                .setAttributeValue(fixStatement.getAttributeValueInterpreter().interpret(match))
                 .setUnsetAttributeValue(fixStatement.isCustomizationRequired())
                 .build();
     }


### PR DESCRIPTION
As part of https://github.com/eMoflon/model-modeling-language-cli/commit/035cbb9795b13ca2da731839324020e3d0a2f486, MatchBasedStringInterpreter were introduced on the model server side, allowing expressions to be evaluated at runtime in the context of a match. This functionality should now also be provided for FixSetStatements, so that not only constant values, but also Boolean and arithmetic expressions can be used in combination with match node attributes.

This pull request adds an analog evaluation of expressions for FixSetStatements.